### PR TITLE
Use the active class correctly

### DIFF
--- a/bomb.js
+++ b/bomb.js
@@ -529,8 +529,8 @@ $( document ).ready(function() {
            
     });
     $('.btn-rachael').click(function(event) {
-        $(this).find('.btn').removeClass('btn-primary').addClass('btn-default');
-        $(event.target).addClass("btn-primary"); 
+        $(this).find('.btn').removeClass('btn-primary').removeClass('active').addClass('btn-default');
+        $(event.target).addClass("btn-primary").addClass("active"); 
 
     });
 


### PR DESCRIPTION
The "complicated wires" module uses the "active" class to figure out how many batteries there are. This class is not being used in the "btn-rachael" group